### PR TITLE
Add a magic word in front of the header

### DIFF
--- a/utp.go
+++ b/utp.go
@@ -35,7 +35,7 @@ const (
 	recvWindow = 1 << 18 // 256KiB
 	// uTP header of 20, +2 for the next extension, and 8 bytes of selective
 	// ACK.
-	maxHeaderSize  = 30
+	maxHeaderSize  = 34
 	maxPayloadSize = minMTU - maxHeaderSize
 	maxRecvSize    = 0x2000
 


### PR DESCRIPTION
This identifies the connection as a Syncthing connection, makes it look less like uTP for interested viewers. Passes the test suite here, and works when copied into our vendoring directory.
